### PR TITLE
Update Environmental Protection to consume 1 day charges

### DIFF
--- a/scripts/environmentalProtection.js
+++ b/scripts/environmentalProtection.js
@@ -38,12 +38,13 @@ Hooks.on('init', () => {
 
 Hooks.on("deleteItem", async (item, options, userId) => {
     if (item.system.slug === "environmental-protection-on") {
-        const armorWorn = getWornArmor(item.parent);
-        if (armorWorn) {
-            await armorWorn.setFlag("sf2e-anachronism-automation", "environmentalProtectionRemaining", Math.max(0, item.remainingDuration.remaining));
+        if (item.system.expired === true) { // Maybe have a system setting to opt into auto-renew after expiring.
+            const deficit = Math.floor(item.system.start.value + item.system.duration.value * 6 - game.time.worldTime) / 6;
+            await setProtectionState(item.parent, true, deficit);
         }
-
-        await setProtectionState(item.parent, false);
+        else{
+            await setProtectionState(item.parent, false);
+        }
     } else if (item.type === "armor") {
         if (await getProtectionState(item.parent)) {
             await item.parent.items.filter(i => i.type === "effect" && i.slug === "environmental-protection-on")[0].delete();
@@ -61,14 +62,13 @@ Hooks.on("updateItem", async (item, update) => {
         } else if (update.system?.equipped?.inSlot === false) {
             if (await getProtectionState(item.parent)) {
                 const effect = item.parent.items.filter(i => i.type === "effect" && i.slug === "environmental-protection-on")[0];
-                await item.setFlag("sf2e-anachronism-automation", "environmentalProtectionRemaining", Math.max(0, effect.remainingDuration.remaining));
                 await effect.delete();
             } else {
                 await updateProtectionDisplay(item.parent.uuid);
             }
         } else if (update.system?.subitems) {
             await resetSingleEnvironmentalProtection(item);
-            if (await getRemainingTime(item) === 0) {
+            if (await getRemainingCharges(item) === 0) {
                 let effect = item.parent.items.filter(i => i.type === "effect" && i.slug === "environmental-protection-on");
                 if (effect.length > 0) {
                     await effect[0].delete();
@@ -137,29 +137,29 @@ function armorHasProtection(armor) {
 }
 
 
-async function getRemainingTime(armor) {
-    let remaining = armor.getFlag("sf2e-anachronism-automation", "environmentalProtectionRemaining");
+async function getRemainingCharges(armor) {
+    let charges = armor.getFlag("sf2e-anachronism-automation", "environmentalProtectionRemaining");
     const actor = armor.parent
-    if (remaining === undefined) {
-        remaining = actor.getFlag("sf2e-anachronism-automation", "environmentalProtectionRemaining");
-        if (remaining === undefined) {
+    if (charges === undefined) {
+        charges = actor.getFlag("sf2e-anachronism-automation", "environmentalProtectionRemaining");
+        if (charges === undefined) {
             await resetSingleEnvironmentalProtection(armor);
-            remaining = armor.getFlag("sf2e-anachronism-automation", "environmentalProtectionRemaining");
+            charges = armor.getFlag("sf2e-anachronism-automation", "environmentalProtectionRemaining");
         } else {
             console.log("sf2e-anachronism-automation | Legacy flag found, unsetting it.")
             actor.unsetFlag("sf2e-anachronism-automation", "environmentalProtectionRemaining");
         }
     }
-    return remaining;
+    return charges;
 }
 
 
 async function resetSingleEnvironmentalProtection(armor) {
-    let duration = 0;
+    let charges = 0;
     if (armorHasProtection(armor)) {
-        duration = Math.max(1, armor.system.level.value) * 24 * 60 * 60;
+        charges = Math.max(1, armor.system.level.value);
     }
-    await armor.setFlag("sf2e-anachronism-automation", "environmentalProtectionRemaining", duration);
+    await armor.setFlag("sf2e-anachronism-automation", "environmentalProtectionRemaining", charges);
 }
 
 
@@ -173,8 +173,8 @@ async function getProtectionState(actor) {
 }
 
 
-async function setProtectionState(actor, setTo) {
-    if (setTo && await getRemainingTime(getWornArmor(actor)) === 0) {
+async function setProtectionState(actor, setTo, deficit) {
+    if (setTo && await getRemainingCharges(getWornArmor(actor)) === 0) {
         ui.notifications.warn("Armor has no charge!");
     } else {
         await actor.setFlag("sf2e-anachronism-automation", "environmentalProtectionStatus", setTo);
@@ -183,12 +183,12 @@ async function setProtectionState(actor, setTo) {
                 await resetSingleEnvironmentalProtection(armor);
             }
         }
-        await updateProtectionDisplay(actor.uuid);
+        await updateProtectionDisplay(actor.uuid, deficit);
     }
 }
 
 
-async function updateProtectionDisplay(actorUuid) {
+async function updateProtectionDisplay(actorUuid, deficit) {
     let actor = await fromUuid(actorUuid);
     if (!actor) return void console.log('sf2e-anachronism-automation | actor not found from UUID');
 
@@ -224,22 +224,32 @@ async function updateProtectionDisplay(actorUuid) {
             existingEffect = existingEffectOn[0];
         }
 
-        description = "Worn armor:<br>- @UUID[" + armorWorn.uuid + "]: Active!";
+        if (!deficit) {
+            deficit = 0;
+        }
+
+        let charges = await getRemainingCharges(armorWorn);
+        if (charges === 0) return void ui.notifications.warn("Your armor has run out of charges for its Environmental Protection OR it is Exposed.");
+        else if (charges === 1) void ui.notifications.warn("Your armor is using its final charge of Environmental Protection");
+        else if (charges === 2) void ui.notifications.info("Your armor has 1 charge of Environmental Protection remaining.")
+        else void ui.notifications.info("Your armor has " + (charges - 1) + " charges remaining.")
+
+        await armorWorn.setFlag("sf2e-anachronism-automation", "environmentalProtectionRemaining", Math.max(0,--charges));
+
+        duration = {
+            unit: "rounds",
+            value: Math.floor(24 * 60 * 60 / 6) + deficit
+        }
+
+        description = "Worn armor:<br>- @UUID[" + armorWorn.uuid + "]: Active! Plus " + await getRemainingCharges(armorWorn) + " remaining charges";
         if (armorList.length !== 0) {
             description += "<br>Your non-equipped armor charges are:";
             for (let armor of armorList) {
-                description += "<br>- @UUID[" + armor.uuid + "]: " + readableTime(await getRemainingTime(armor));
+                description += "<br>- @UUID[" + armor.uuid + "]: " + await getRemainingCharges(armor) + " charges";
             }
         }
 
         image = "modules/sf2e-anachronism/art/icons/abilities/blue-event-horizon.webp";
-
-        let remaining = await getRemainingTime(armorWorn);
-        if (remaining === 0) return void ui.notifications.warn("Your armor has run out of duration for its Environmental Protection OR it is Exposed.");
-        duration = {
-            unit: "rounds",
-            value: Math.floor(remaining / 6)
-        }
 
         if (getSetting('environmental-protection-plus')) {
             rules.push({
@@ -259,7 +269,7 @@ async function updateProtectionDisplay(actorUuid) {
         }
 
         if (armorWorn) {
-            description = "Worn armor:<br>- @UUID[" + armorWorn.uuid + "]: " + readableTime(await getRemainingTime(armorWorn));
+            description = "Worn armor:<br>- @UUID[" + armorWorn.uuid + "]: " + await getRemainingCharges(armorWorn) + " charges";
         }
         if (armorWorn && armorList.length !== 0) {
             description += "<br>";
@@ -267,7 +277,7 @@ async function updateProtectionDisplay(actorUuid) {
         if (armorList.length !== 0) {
             description += "Your non-equipped armor charges are:";
             for (let armor of armorList) {
-                description += "<br>- @UUID[" + armor.uuid + "]: " + readableTime(await getRemainingTime(armor));
+                description += "<br>- @UUID[" + armor.uuid + "]: " + await getRemainingCharges(armor) + " charges";
             }
         }
 

--- a/scripts/environmentalProtection.js
+++ b/scripts/environmentalProtection.js
@@ -30,6 +30,16 @@ Hooks.on('init', () => {
         default: true,
         requiresReload: false
     })
+
+    game.settings.register('sf2e-anachronism-automation', 'auto-renew-environmental-protection', {
+        name: 'Auto-Renew Environmental Protection',
+        hint: 'When the 24 hour duration of a single Environmental Protection charge expires, set this to automatically activate the next charge if one is available.',
+        scope: 'world',
+        config: true,
+        type: Boolean,
+        default: true,
+        requiresReload: false
+    })
 });
 
 
@@ -38,7 +48,7 @@ Hooks.on('init', () => {
 
 Hooks.on("deleteItem", async (item, options, userId) => {
     if (item.system.slug === "environmental-protection-on") {
-        if (item.system.expired === true) { // Maybe have a system setting to opt into auto-renew after expiring.
+        if (getSetting('auto-renew-environmental-protection') && item.system.expired === true) {
             const deficit = Math.floor(item.system.start.value + item.system.duration.value * 6 - game.time.worldTime) / 6;
             await setProtectionState(item.parent, true, deficit);
         }


### PR DESCRIPTION
As you mentioned in the readme, the Environmental Protection should be measured in 1 day charges. This changes the effect to always last 24 hours, and when it is activated it deducts 1 charge from the remaining charges on the armor.

There's also an option to allow the player to auto-renew the effect when it expires, so it automatically expends another charge to refresh the effect for another 24 hours. At the moment this option is module wide but maybe it could be toggled per character?

---

Side note, I'm enjoying the module! I'm also planning a Starfinder 2e Campaign, one in which the players are stranded far from home and exploring distant unknown planets. I wanted to make sure Environmental Protection was tracked for my campaign, so I figured I would contribute so I could use this myself.

I've got a homebrew variant of the Environmental Protection rules that includes a separate set of charges for breathable air in a vacuum, which have a much shorter duration so vacuum fighting at low level is more dangerous, while the rest of the protections can work mostly the same. I wanted to make a module similar to this for my homebrew but you kinda beat me to it, at least for the RAW implementation.